### PR TITLE
chore: :green_heart: update the VM image for the Build stage to windo…

### DIFF
--- a/azure-pipelines-android.yml
+++ b/azure-pipelines-android.yml
@@ -5,7 +5,7 @@ stages:
 - stage: Build
   # Android ManifestのXMLファイル処理のためWindowsを使用
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2025-vs2026'
 
   jobs:
   - job: GenerateAab


### PR DESCRIPTION
…ws-2025-vs2026

We changed the virtual machine image used in the Build stage of `azure-pipelines-android.yml` from the previous `windows-latest` to `windows-2025-vs2026`. This ensures builds run on a newer Windows environment.